### PR TITLE
Fixing libbtlv include path at lint scripts

### DIFF
--- a/scripts/checkFormat.sh
+++ b/scripts/checkFormat.sh
@@ -62,7 +62,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # BTLV Lib headers
-filesSearchDiff "include" "*.h"
+filesSearchDiff "src/include" "*.h"
 
 # BTLV Lib sources
 filesSearchDiff "src" "*.c"

--- a/scripts/formatCodeFiles.sh
+++ b/scripts/formatCodeFiles.sh
@@ -24,7 +24,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # BTLV Lib headers
-formatFiles "include" "*.h"
+formatFiles "src/include" "*.h"
 
 # BTLV Lib sources
 formatFiles "src" "*.c"


### PR DESCRIPTION
# Description

* Fixing lint scripts (checkFormat and formatCodeFiles) because the path of libbtlv headers changed and the scripts were not updated.